### PR TITLE
TransactionPage 기본틀 구현

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,7 +1,12 @@
 <template>
-  <div></div>
+  <div>
+    <TransactionPage />
+  </div>
 </template>
 
-<script setup></script>
+<script setup>
+import TransactionItem from './components/TransactionItem.vue';
+import TransactionPage from './views/TransactionPage.vue';
+</script>
 
 <style scoped></style>

--- a/src/components/TransactionItem.vue
+++ b/src/components/TransactionItem.vue
@@ -1,7 +1,14 @@
 <template>
-  <div></div>
+  <li style="list-style: none">
+    <!-- 클릭하면 상세 내역 보기 -->
+    <span>
+      {{ index + 1 }} {{ trans.date }} {{ trans.amount }} {{ trans.category }}
+    </span>
+  </li>
 </template>
 
-<script setup></script>
+<script setup>
+defineProps(['trans', 'index']);
+</script>
 
 <style scoped></style>

--- a/src/stores/transactionStore.js
+++ b/src/stores/transactionStore.js
@@ -1,0 +1,21 @@
+import { defineStore } from 'pinia';
+import { ref } from 'vue';
+import axios from 'axios';
+
+export const useTransactionStore = defineStore('transaction', () => {
+  const transactions = ref([]);
+
+  const fetchTransactions = async () => {
+    try {
+      const res = await axios.get('/api/transaction');
+      transactions.value = res.data;
+    } catch (e) {
+      console.error('가계부 내역 불러오기 실패', e);
+    }
+  };
+
+  return {
+    transactions,
+    fetchTransactions,
+  };
+});

--- a/src/views/TransactionPage.vue
+++ b/src/views/TransactionPage.vue
@@ -1,7 +1,78 @@
 <template>
-  <div></div>
+  <div>
+    <span>전체 내역</span>
+    <TransactionItem
+      v-for="(trans, index) in paginationTransactions"
+      :key="trans.id"
+      :trans="trans"
+      :index="index"
+    />
+    <nav aria-label="Page navigation example">
+      <ul class="pagination">
+        <li class="page-item">
+          <button
+            class="page-link"
+            aria-label="Previous"
+            @click="goToPage(currentPage - 1)"
+          >
+            <span aria-hidden="true">&laquo;</span>
+          </button>
+        </li>
+        <li
+          class="page-item"
+          v-for="page in totalPages"
+          :key="page"
+          :class="{ active: page === currentPage }"
+        >
+          <button class="page-link" @click="goToPage(page)">{{ page }}</button>
+        </li>
+        <li class="page-item">
+          <button
+            class="page-link"
+            aria-label="Next"
+            @click="currentPage(page + 1)"
+          >
+            <span aria-hidden="true">&raquo;</span>
+          </button>
+        </li>
+      </ul>
+    </nav>
+  </div>
 </template>
 
-<script setup></script>
+<script setup>
+import TransactionItem from '@/components/TransactionItem.vue';
+import { useTransactionStore } from '@/stores/transactionStore';
+import { storeToRefs } from 'pinia';
+import { ref, computed } from 'vue';
+
+const store = useTransactionStore();
+store.fetchTransactions();
+
+const { transactions } = storeToRefs(store);
+
+// 페이징 관련
+const currentPage = ref(1);
+const itemsPerPage = 10;
+
+// Math.ceil 올림 함수 transaction 갯수 / 10 으로 페이지 수 정함
+const totalPages = computed(() =>
+  Math.ceil(transactions.value.length / itemsPerPage)
+);
+// 페이지에 따른 가계부 내역
+const paginationTransactions = computed(() => {
+  const start = (currentPage.value - 1) * itemsPerPage; // 1 페이지 0부터 2 페이지 10부터
+  const end = start + itemsPerPage;
+  // slice end 값 미포함
+  return transactions.value.slice(start, end);
+});
+
+// 페이지 이동
+function goToPage(page) {
+  if (page >= 1 && page <= totalPages.value) {
+    currentPage.value = page;
+  }
+}
+</script>
 
 <style scoped></style>


### PR DESCRIPTION
### TransactionList.vue
일단 안 쓸 거 같아 구현 안 했습니다.
추후에도 필요없다 판단 되면 삭제하겠습니다.

### TransactionItem.vue
아직 클릭하면 상세 내역 보기 기능은 안 넣어서 주석으로 적어놨습니다.

### TransactionPage.vue
이건 테스트 위해서 지금 App.vue에 적혀있습니다.
현재는 각 페이지 당 10개 요소가 보이게 했고
데이터가 20개 뿐이라 페이지가 2개 존재합니다.
추후에 router-view 통해서 보면 될 것 같습니다.
